### PR TITLE
Use correct architectures values in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=NMEA and ublox GPS parser, configurable to use as few as 10 bytes of RA
 paragraph=Faster and smaller than all other GPS parsers
 category=Communication
 url=https://github.com/SlashDevin/NeoGPS
-architectures=avr,SAMD,SAM
+architectures=avr,samd,sam
 includes=NMEAGPS.h


### PR DESCRIPTION
When a SAMD or SAM based board is selected the incorrect `architectures` values `SAMD` and `SAM` cause the NeoGPS example sketches to not show in the **File > Examples** menu and the warning:
```
WARNING: library NeoGPS claims to run on [avr architecture(s) and may be incompatible with your current board which runs on SAMD architecture(s).
```
is shown on compilation.