### PR TITLE
Validate N/S and E/W characters

### DIFF
--- a/src/NMEAGPS.cpp
+++ b/src/NMEAGPS.cpp
@@ -1328,6 +1328,10 @@ bool NMEAGPS::parseLat( char chr )
 bool NMEAGPS::parseNS( char chr )
 {
   #if defined( GPS_FIX_LOCATION ) | defined( GPS_FIX_LOCATION_DMS )
+    if ((chr == ',') && (chrCount == 0) || 
+        ((chr != ',') && (chr != 'N') && (chr != 'S')))
+      group_valid = false;
+
     if (group_valid && (chr == 'S')) {
       #ifdef GPS_FIX_LOCATION
         m_fix.location._lat = -m_fix.location._lat;
@@ -1373,6 +1377,10 @@ bool NMEAGPS::parseLon( char chr )
 bool NMEAGPS::parseEW( char chr )
 {
   #if defined( GPS_FIX_LOCATION ) | defined( GPS_FIX_LOCATION_DMS )
+    if ((chr == ',') && (chrCount == 0) || 
+        ((chr != ',') && (chr != 'E') && (chr != 'W')))
+      group_valid = false;
+
     if (group_valid) {
       if (chr == 'W') {
         #ifdef GPS_FIX_LOCATION


### PR DESCRIPTION
When looking for latitude and longitude, the N/S and E/W characters were not being checked.  This can cause trouble in the rare case of a truncated GGA message that happens to have the correct checksum.

For example (a real capture via telemetry radio that dropped a portion of the message...):

$GPGGA,201019.00,3249.20458,N,1,-25.6,M,,*6A

Ideally, all NMEA messages should be checked for the proper number of fields too (future work).

--Jay
