### PR TITLE
Added support for UBX HNR PVT messages (High Rate Output of PVT Solution)

### DIFF
--- a/src/ublox/ubxGPS.cpp
+++ b/src/ublox/ubxGPS.cpp
@@ -990,7 +990,7 @@ bool ubloxGPS::parseHnrPvt( uint8_t chr )
         case 17:
         {
             ublox::hnr_pvt_t::flags_t flags = *((ublox::hnr_pvt_t::flags_t *) &chr);
-            m_fix.status = ublox::hnr_pvt_t::to_status( (ublox::hnr_pvt_t::status_t) m_fix.status, flags );
+            m_fix.status = ublox::hnr_pvt_t::to_status( (ublox::nav_status_t::status_t) m_fix.status, flags );
             break;
         }
 

--- a/src/ublox/ubxGPS.cpp
+++ b/src/ublox/ubxGPS.cpp
@@ -516,11 +516,8 @@ bool ubloxGPS::parseNavStatus( uint8_t chr )
         break;
       case 5:
         {
-          ublox::nav_status_t::flags_t flags =
-            *((ublox::nav_status_t::flags_t *) &chr);
-          m_fix.status =
-            ublox::nav_status_t::to_status
-              ( (ublox::nav_status_t::status_t) m_fix.status, flags );
+          ublox::nav_status_t::flags_t flags = *((ublox::nav_status_t::flags_t *) &chr);
+          m_fix.status = ublox::nav_status_t::to_status( m_fix.status, flags );
 //trace << m_fix.status << ' ';
         }
         break;
@@ -990,7 +987,7 @@ bool ubloxGPS::parseHnrPvt( uint8_t chr )
         case 17:
         {
             ublox::hnr_pvt_t::flags_t flags = *((ublox::hnr_pvt_t::flags_t *) &chr);
-            m_fix.status = ublox::hnr_pvt_t::to_status( (ublox::nav_status_t::status_t) m_fix.status, flags );
+            m_fix.status = ublox::hnr_pvt_t::to_status( m_fix.status, flags );
             break;
         }
 

--- a/src/ublox/ubxGPS.h
+++ b/src/ublox/ubxGPS.h
@@ -294,6 +294,8 @@ private:
     bool parseNavTimeUTC( uint8_t chr );
     bool parseNavSVInfo ( uint8_t chr );
 
+    bool parseHnrPvt( uint8_t chr );
+
     bool parseFix( uint8_t c );
 
     bool parseTOW( uint8_t chr )

--- a/src/ublox/ubx_cfg.h
+++ b/src/ublox/ubx_cfg.h
@@ -17,6 +17,7 @@
 //#define UBLOX_PARSE_SVINFO
 //#define UBLOX_PARSE_CFGNAV5
 //#define UBLOX_PARSE_MONVER
+//#define UBLOX_PARSE_HNR_PVT
 
 //--------------------------------------------------------------------
 // Identify the last UBX message in an update interval.
@@ -24,18 +25,23 @@
 // For coherency, you must determine which UBX message is last!
 // This section *should* pick the correct last UBX message for NEO-6M devices.
 
-#define UBX_LAST_MSG_CLASS_IN_INTERVAL ublox::UBX_NAV
-
 #if defined(UBLOX_PARSE_DOP)
-  #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_DOP
-#elif defined(UBLOX_PARSE_VELNED)
-  #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_VELNED
-#elif defined(UBLOX_PARSE_POSLLH)
-  #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_POSLLH
-#elif defined(UBLOX_PARSE_SVINFO)
-  #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_SVINFO
+  #define UBX_LAST_MSG_CLASS_IN_INTERVAL ublox::UBX_HNR
+  #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_HNR_PVT
 #else
-  #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_STATUS
+  #define UBX_LAST_MSG_CLASS_IN_INTERVAL ublox::UBX_NAV
+
+  #if defined(UBLOX_PARSE_DOP)
+    #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_DOP
+  #elif defined(UBLOX_PARSE_VELNED)
+    #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_VELNED
+  #elif defined(UBLOX_PARSE_POSLLH)
+    #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_POSLLH
+  #elif defined(UBLOX_PARSE_SVINFO)
+    #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_SVINFO
+  #else
+    #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_NAV_STATUS
+  #endif
 #endif
 
 #endif

--- a/src/ublox/ubx_cfg.h
+++ b/src/ublox/ubx_cfg.h
@@ -25,7 +25,7 @@
 // For coherency, you must determine which UBX message is last!
 // This section *should* pick the correct last UBX message for NEO-6M devices.
 
-#if defined(UBLOX_PARSE_DOP)
+#if defined(UBLOX_PARSE_HNR_PVT)
   #define UBX_LAST_MSG_CLASS_IN_INTERVAL ublox::UBX_HNR
   #define UBX_LAST_MSG_ID_IN_INTERVAL    ublox::UBX_HNR_PVT
 #else

--- a/src/ublox/ubxmsg.h
+++ b/src/ublox/ubxmsg.h
@@ -455,15 +455,7 @@ namespace ublox {
         valid;
         int32_t  fractional_ToW; // nS
 
-        enum status_t {
-            NAV_STAT_NONE,
-            NAV_STAT_DR_ONLY,
-            NAV_STAT_2D,
-            NAV_STAT_3D,
-            NAV_STAT_GPS_DR,
-            NAV_STAT_TIME_ONLY
-        } __attribute__((packed))
-        status;
+        nav_status_t::status_t status;
 
         struct flags_t {
             bool gps_fix:1;
@@ -474,19 +466,19 @@ namespace ublox {
         } __attribute__((packed))
         flags;
 
-        static gps_fix::status_t to_status( enum status_t status, flags_t flags )
+        static gps_fix::status_t to_status( enum nav_status_t::status_t status, flags_t flags )
         {
             if (!flags.gps_fix)
-            return gps_fix::STATUS_NONE;
+              return gps_fix::STATUS_NONE;
             if (flags.diff_soln)
-            return gps_fix::STATUS_DGPS;
+              return gps_fix::STATUS_DGPS;
             switch (status) {
-                case NAV_STAT_DR_ONLY  : return gps_fix::STATUS_EST;
-                case NAV_STAT_2D       :
-                case NAV_STAT_3D       :
-                case NAV_STAT_GPS_DR   : return gps_fix::STATUS_STD;
-                case NAV_STAT_TIME_ONLY: return gps_fix::STATUS_TIME_ONLY;
-                default                : return gps_fix::STATUS_NONE;
+              case nav_status_t::status_t::NAV_STAT_DR_ONLY  : return gps_fix::STATUS_EST;
+              case nav_status_t::status_t::NAV_STAT_2D       :
+              case nav_status_t::status_t::NAV_STAT_3D       :
+              case nav_status_t::status_t::NAV_STAT_GPS_DR   : return gps_fix::STATUS_STD;
+              case nav_status_t::status_t::NAV_STAT_TIME_ONLY: return gps_fix::STATUS_TIME_ONLY;
+              default                : return gps_fix::STATUS_NONE;
             }
         }
 

--- a/src/ublox/ubxmsg.h
+++ b/src/ublox/ubxmsg.h
@@ -266,20 +266,13 @@ namespace ublox {
         } __attribute__((packed))
           flags;
         
-        static gps_fix::status_t to_status( enum status_t status, flags_t flags )
+        static gps_fix::status_t to_status( enum gps_fix::status_t status, flags_t flags )
         {
           if (!flags.gps_fix)
             return gps_fix::STATUS_NONE;
           if (flags.diff_soln)
             return gps_fix::STATUS_DGPS;
-          switch (status) {
-            case NAV_STAT_DR_ONLY  : return gps_fix::STATUS_EST;
-            case NAV_STAT_2D       :
-            case NAV_STAT_3D       :
-            case NAV_STAT_GPS_DR   : return gps_fix::STATUS_STD;
-            case NAV_STAT_TIME_ONLY: return gps_fix::STATUS_TIME_ONLY;
-            default                : return gps_fix::STATUS_NONE;
-          }
+          return status;
         }
         
         struct {
@@ -466,20 +459,13 @@ namespace ublox {
         } __attribute__((packed))
         flags;
 
-        static gps_fix::status_t to_status( enum nav_status_t::status_t status, flags_t flags )
+        static gps_fix::status_t to_status( enum gps_fix::status_t status, flags_t flags )
         {
             if (!flags.gps_fix)
               return gps_fix::STATUS_NONE;
             if (flags.diff_soln)
               return gps_fix::STATUS_DGPS;
-            switch (status) {
-              case nav_status_t::status_t::NAV_STAT_DR_ONLY  : return gps_fix::STATUS_EST;
-              case nav_status_t::status_t::NAV_STAT_2D       :
-              case nav_status_t::status_t::NAV_STAT_3D       :
-              case nav_status_t::status_t::NAV_STAT_GPS_DR   : return gps_fix::STATUS_STD;
-              case nav_status_t::status_t::NAV_STAT_TIME_ONLY: return gps_fix::STATUS_TIME_ONLY;
-              default                : return gps_fix::STATUS_NONE;
-            }
+            return status;
         }
 
         uint16_t reserved1;

--- a/src/ublox/ubxmsg.h
+++ b/src/ublox/ubxmsg.h
@@ -20,6 +20,7 @@ namespace ublox {
         UBX_MON  = 0x0A,  // Monitoring messages
         UBX_AID  = 0x0B,  // Assist Now aiding messages
         UBX_TIM  = 0x0D,  // Timing messages
+        UBX_HNR  = 0x28,  // High rate navigation results
         UBX_NMEA = 0xF0,  // NMEA Standard messages
         UBX_PUBX = 0xF1,  // NMEA proprietary messages (PUBX)
         UBX_UNK  = 0xFF
@@ -44,6 +45,7 @@ namespace ublox {
         UBX_NAV_TIMEGPS  = 0x20, // Current GPS Time
         UBX_NAV_TIMEUTC  = 0x21, // Current UTC Time
         UBX_NAV_SVINFO   = 0x30, // Space Vehicle Information
+        UBX_HNR_PVT      = 0x00, // High rate Position, Velocity and Time
         UBX_ID_UNK   = 0xFF
       }  __attribute__((packed));
 
@@ -435,6 +437,80 @@ namespace ublox {
         }
 
       }  __attribute__((packed));
+
+    // High Rate PVT
+    struct hnr_pvt_t : msg_t {
+        uint32_t time_of_week;   // mS
+        uint16_t year;           // 1999..2099
+        uint8_t  month;          // 1..12
+        uint8_t  day;            // 1..31
+        uint8_t  hour;           // 0..23
+        uint8_t  minute;         // 0..59
+        uint8_t  second;         // 0..59
+        struct valid_t {
+            bool date:1;
+            bool time:1;
+            bool fully_resolved:1;
+        } __attribute__((packed))
+        valid;
+        int32_t  fractional_ToW; // nS
+
+        enum status_t {
+            NAV_STAT_NONE,
+            NAV_STAT_DR_ONLY,
+            NAV_STAT_2D,
+            NAV_STAT_3D,
+            NAV_STAT_GPS_DR,
+            NAV_STAT_TIME_ONLY
+        } __attribute__((packed))
+        status;
+
+        struct flags_t {
+            bool gps_fix:1;
+            bool diff_soln:1;
+            bool week:1;
+            bool time_of_week:1;
+            bool heading_valid:1;
+        } __attribute__((packed))
+        flags;
+
+        static gps_fix::status_t to_status( enum status_t status, flags_t flags )
+        {
+            if (!flags.gps_fix)
+            return gps_fix::STATUS_NONE;
+            if (flags.diff_soln)
+            return gps_fix::STATUS_DGPS;
+            switch (status) {
+                case NAV_STAT_DR_ONLY  : return gps_fix::STATUS_EST;
+                case NAV_STAT_2D       :
+                case NAV_STAT_3D       :
+                case NAV_STAT_GPS_DR   : return gps_fix::STATUS_STD;
+                case NAV_STAT_TIME_ONLY: return gps_fix::STATUS_TIME_ONLY;
+                default                : return gps_fix::STATUS_NONE;
+            }
+        }
+
+        uint16_t reserved1;
+
+        int32_t  lon; // deg * 1e7
+        int32_t  lat; // deg * 1e7
+        int32_t  height_above_ellipsoid; // mm
+        int32_t  height_MSL; // mm
+
+        int32_t  speed_2D;        // mm/s
+        int32_t  speed_3D;        // mm/s
+        int32_t  heading_motion;  // degrees * 1e5
+        int32_t  heading_vehicle; // degrees * 1e5
+
+        uint32_t horiz_acc;   // mm
+        uint32_t vert_acc;    // mm
+        uint32_t speed_acc;   // mm/s
+        uint32_t heading_acc; // degrees * 1e5
+
+        uint32_t reserved4;
+
+        hnr_pvt_t() : msg_t( UBX_HNR, UBX_HNR_PVT, UBX_MSG_LEN(*this) ) {};
+    } __attribute__((packed));
 
     struct cfg_nmea_t : msg_t {
         bool  always_output_pos  :1; // invalid or failed


### PR DESCRIPTION
Tested with a Ublox Neo-M8U module, but only as the sole message being parsed.

This change was developed against a slightly older version, from before the recent cleanup.

Please verify the speed calculation as this message uses mm/s and a signed value - Some of the magic numbers in the calculation are not documented (E.g: 125). I compared the calculations with some test values and they are close, but the precision has changed for large values.