### PR TITLE
Use hardware serial port on Teensy boards

### DIFF
--- a/src/GPSport.h
+++ b/src/GPSport.h
@@ -129,7 +129,7 @@
 //             *DELETE* the rest of this file and declare your own port
 //             and port name string (see above).
 
-#if defined( UBRR1H ) | defined( ID_USART0 )
+#if defined( UBRR1H ) | defined( ID_USART0 ) | defined( TEENSYDUINO )
   //  If the Arduino has more than one hardware serial port, 
   //      use Serial1 (or NeoSerial1).
 


### PR DESCRIPTION
All Teensy boards have Serial1 which is not shared with USB.

... and thanks for the kind words about AltSoftSerial... (I'm the author)