### PR TITLE
Allow compile under PlatformIO for esp8266

### DIFF
--- a/src/NeoGPS_cfg.h
+++ b/src/NeoGPS_cfg.h
@@ -88,7 +88,7 @@
 //  The CONST_CLASS_DATA define will expand to the appropriate keywords.
 //
 
-#if (ARDUINO < 10606) | ((10700 <= ARDUINO) & (ARDUINO <= 10799)) | ((107000 <= ARDUINO) & (ARDUINO <= 107999))
+#if ((ARDUINO < 10606) | ((10700 <= ARDUINO) & (ARDUINO <= 10799)) | ((107000 <= ARDUINO) & (ARDUINO <= 107999)) )& !defined(ESP8266)
 
   #define CONST_CLASS_DATA static const
   


### PR DESCRIPTION
This ensures "static constexpr" is used under platform espressif8266 and avoids compile errors.