### PR TITLE
removed HDOP from Nominal documentation as its is missing from GPSFix…

### DIFF
--- a/extras/doc/Configurations.md
+++ b/extras/doc/Configurations.md
@@ -242,7 +242,7 @@ A few common configurations are defined as follows
 **DTL**: date, time, lat/lon, GPRMC messsage only.
 
 **Nominal**: date, time, lat/lon, altitude, speed, heading, number of 
-satellites, HDOP, GPRMC and GPGGA messages.
+satellites, GPRMC and GPGGA messages.
 
 **Full**: Nominal plus talker ID, VDOP, PDOP, lat/lon/alt errors, satellite array with satellite info, all messages, and parser statistics.
 


### PR DESCRIPTION
…_cfg.h

Hi, 

I think there may be a documentation or config error.

The documentation suggests the nominal config reports HDOP, yet it is commented out in the GPSfix_cfg.h

`//#define GPS_FIX_HDOP`
See; https://github.com/SlashDevin/NeoGPS/blob/master/extras/configs/Nominal/GPSfix_cfg.h#L27

This pull request corrects the documentation - an alternative is to uncomment that line, as the correct sentences `#define NMEAGPS_PARSE_GGA` are configured in;

https://github.com/SlashDevin/NeoGPS/blob/master/extras/configs/Nominal/NMEAGPS_cfg.h#L14