### PR TITLE
TimeLib defines DAYS_PER_WEEK as type time_t with a value of 7. TimeL…

### DIFF
--- a/src/NeoTime.h
+++ b/src/NeoTime.h
@@ -41,7 +41,9 @@ const uint8_t  MINUTES_PER_HOUR   = 60;
 const uint16_t SECONDS_PER_HOUR   = (uint16_t) SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
 const uint8_t  HOURS_PER_DAY      = 24;
 const uint32_t SECONDS_PER_DAY    = (uint32_t) SECONDS_PER_HOUR * HOURS_PER_DAY;
-const uint8_t  DAYS_PER_WEEK      = 7;
+#ifndef DAYS_PER_WEEK
+	const uint8_t  DAYS_PER_WEEK      = 7;
+#endif
 
 /**
  * Common date/time structure
@@ -192,7 +194,7 @@ struct time_t {
    */
   static uint8_t weekday_for(uint16_t dayno)
   {
-    return ((dayno+epoch_weekday()-1) % DAYS_PER_WEEK) + 1;
+    return ((dayno+epoch_weekday()-1) % (uint8_t)DAYS_PER_WEEK) + 1;
   }
 
   /**


### PR DESCRIPTION
…ib's time_t is defined as unsigned long with a value of 7. This is compatable with NeoGPS declaration of DAYS_PER_WEEK with type uint8_t if cast to uint8_t. I modified the code to check if DAYS_PER_WEEK is defined and cast DAYS_PER_WEEK as uint8_t when used.

This is an alternate way to resolve the conflict between NeoGPS and TimeLib. User, tscofield, proposed a similar fix by renaming DAYS_PER_WEEK but I believe this may be a slightly better resolution to the issue.

See issues

- [https://github.com/SlashDevin/NeoGPS/pull/115](https://github.com/SlashDevin/NeoGPS/pull/115 "NeoGPS Issue 115")
- [https://github.com/PaulStoffregen/Time/issues/163](https://github.com/PaulStoffregen/Time/issues/163 "TimeLib Issue 163")

BTW: I looked into applying a similar fix to TimeLib but the issue only seemed to be resolved when applied to NeoGPS.