### PR TITLE
Conflict with esp32 timelib.h fix

### DIFF
--- a/src/NeoTime.h
+++ b/src/NeoTime.h
@@ -41,7 +41,7 @@ const uint8_t  MINUTES_PER_HOUR   = 60;
 const uint16_t SECONDS_PER_HOUR   = (uint16_t) SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
 const uint8_t  HOURS_PER_DAY      = 24;
 const uint32_t SECONDS_PER_DAY    = (uint32_t) SECONDS_PER_HOUR * HOURS_PER_DAY;
-const uint8_t  DAYS_PER_WEEK      = 7;
+const uint8_t  DAYS_PER_WEEK_M      = 7;
 
 /**
  * Common date/time structure
@@ -192,7 +192,7 @@ struct time_t {
    */
   static uint8_t weekday_for(uint16_t dayno)
   {
-    return ((dayno+epoch_weekday()-1) % DAYS_PER_WEEK) + 1;
+    return ((dayno+epoch_weekday()-1) % DAYS_PER_WEEK_M) + 1;
   }
 
   /**


### PR DESCRIPTION
NeoTime.h 4.2.9
Line 44
const uint8_t  DAYS_PER_WEEK     = 7; 

Conflicts with compilation due to a define in esp32 Timelib 1.6.1
(https://github.com/PaulStoffregen/Time/blob/master/TimeLib.h)
Line 70
#define DAYS_PER_WEEK ((time_t)(7UL))

And causes a compilation error. 

Renaming variable name to resolve.