### PR TITLE
fix: Add missing return statement for bool parseNavPvt

### DIFF
--- a/src/ublox/ubxGPS.cpp
+++ b/src/ublox/ubxGPS.cpp
@@ -916,6 +916,8 @@ bool ubloxGPS::parseNavPvt( uint8_t chr )
     }
   #endif
 
+  return ok;
+
 } // parseNavPvt
 
 //---------------------------------------------------------


### PR DESCRIPTION
The non-void function ubloxGPS::parseNavPvt( uint8_t chr ) is missing a return function.